### PR TITLE
made solved wordles replace instead of refill

### DIFF
--- a/script.js
+++ b/script.js
@@ -142,10 +142,9 @@ function pressEnter() {
         if (index > -1) {
             remaininganswers.splice(index, 1);
             wordFound();
-            while (currentanswers.indexOf(word) > -1) {
-                currentanswers.splice(currentanswers.indexOf(word), 1);
-            }
-            refillWords();
+            for (i = 0; i < currentanswers.length; i++)
+                if (currentanswers[i] === word)
+                    currentanswers[i] =remaininganswers[Math.floor(Math.random() * remaininganswers.length)];
         }
         setclues();
         writeLetters();


### PR DESCRIPTION
When a word was guessed correctly, it used to remove it, move all further wordles left and add a new one at the end. Now it replaces the wordle at it's own spot and keeps all the others the same.